### PR TITLE
Bug fix in bio/deseq2/DESeqDataSetFromMatrix/wrapper.R and in bigr_pipelines/rnaseq/rules/029.clusterprofiler.terms.smk on the Unofficial branch

### DIFF
--- a/bigr_pipelines/rnaseq/rules/029.clusterprofiler.terms.smk
+++ b/bigr_pipelines/rnaseq/rules/029.clusterprofiler.terms.smk
@@ -20,7 +20,7 @@ rule term2gene_TERMS_PPI:
         tmpdir="tmp",
     params:
         begin='FS=OFS="\t"',
-        body=["print $3 FS $1"],
+        body=["{print $3 FS $1}"],
     group:
         "prepare_terms_ppi"
     log:
@@ -51,7 +51,7 @@ rule terms2name_TERMS_PPI:
         tmpdir="tmp",
     params:
         begin='FS=OFS="\t"',
-        body=["print $3 FS $4"],
+        body=["{print $3 FS $4}"],
     group:
         "prepare_terms_ppi"
     log:

--- a/bio/deseq2/DESeqDataSetFromMatrix/wrapper.R
+++ b/bio/deseq2/DESeqDataSetFromMatrix/wrapper.R
@@ -40,7 +40,7 @@ if ("count_filter" %in% names(snakemake@params)) {
     x = snakemake@params[["count_filter"]]
   );
 }
-keep <- rowSums(head(counts)) > count_filter;
+keep <- rowSums(counts) > count_filter;
 counts <- counts[keep, ];
 
 base::message("Counts loaded");


### PR DESCRIPTION
<!-- Ensure that the PR title follows conventional commit style (<type>: <description>)-->
<!-- Possible types are here: https://github.com/commitizen/conventional-commit-types/blob/master/index.json -->

<!-- Add a description of your PR here-->

### QC
<!-- Make sure that you can tick the boxes below. -->

* [ ] I confirm that:

For all wrappers added by this PR, 

* there is a test case which covers any introduced changes,
* `input:` and `output:` file paths in the resulting rule can be changed arbitrarily,
* either the wrapper can only use a single core, or the example rule contains a `threads: x` statement with `x` being a reasonable default,
* rule names in the test case are in [snake_case](https://en.wikipedia.org/wiki/Snake_case) and somehow tell what the rule is about or match the tools purpose or name (e.g., `map_reads` for a step that maps reads),
* all `environment.yaml` specifications follow [the respective best practices](https://stackoverflow.com/a/64594513/2352071),
* the `environment.yaml` pinning has been updated by running `snakedeploy pin-conda-envs environment.yaml` on a linux machine,
* wherever possible, command line arguments are inferred and set automatically (e.g. based on file extensions in `input:` or `output:`),
* all fields of the example rules in the `Snakefile`s and their entries are explained via comments (`input:`/`output:`/`params:` etc.),
* `stderr` and/or `stdout` are logged correctly (`log:`), depending on the wrapped tool,
* temporary files are either written to a unique hidden folder in the working directory, or (better) stored where the Python function `tempfile.gettempdir()` points to (see [here](https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir); this also means that using any Python `tempfile` default behavior works),
* the `meta.yaml` contains a link to the documentation of the respective tool or command,
* `Snakefile`s pass the linting (`snakemake --lint`),
* `Snakefile`s are formatted with [snakefmt](https://github.com/snakemake/snakefmt),
* Python wrapper scripts are formatted with [black](https://black.readthedocs.io).
* Conda environments use a minimal amount of channels, in recommended ordering. E.g. for bioconda, use (conda-forge, bioconda, nodefaults, as conda-forge should have highest priority and defaults channels are usually not needed because most packages are in conda-forge nowadays).
